### PR TITLE
Create php.ruleset.xml

### DIFF
--- a/PHP/phpcs.ruleset.xml
+++ b/PHP/phpcs.ruleset.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruleset name="log-Base">
+  <description>log coding standards for WordPress projects.</description>
+
+  <exclude-pattern>*/phpunit.xml*</exclude-pattern>
+  <exclude-pattern>*/languages/*</exclude-pattern>
+  <exclude-pattern>*/tests/*</exclude-pattern>
+
+  <exclude-pattern>*/node_modules/*</exclude-pattern>
+  <exclude-pattern>*/vendor/*</exclude-pattern>
+
+  <!-- Yoda conditions, we must ignore -->
+  <rule ref="WordPress.PHP.YodaConditions.NotYoda">
+    <severity>0</severity>
+  </rule>
+
+  <!-- Ignore lowercase filenames -->
+  <rule ref="Generic.Files.LowercasedFilename.NotFound">
+    <severity>0</severity>
+  </rule>
+
+  <rule ref="WordPress-Extra" />
+</ruleset>


### PR DESCRIPTION
Custom exceptions to WordPress Coding standards in log's Standards.